### PR TITLE
IN-124: Update handling of axios error responses in sentry transport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,7 @@
 
 ## Requirements
 
-* Node v8.1.3
-* NPM v5.3.0
-
-## Installation
-
-1. Copy `.env.template` in same directory and rename it to `.env`.
-1. Update `.env` file.
-1. Run `npm i`.
+* Node >=8.3.0
 
 ## Features
 
@@ -22,27 +15,18 @@
 * Logger integration with Sentry.
 
 
-## Usage
-
-1. Add dependency to `package.json` file (e.g. `https://github.com/RideRoundTrip/roundtrip-micro#1.0.4`)
-2. Add `.env` file (see sample below)
-3. Run `npm i`
-
-## Sample ENV File
+## Available Environment Variables
 
 ```bash
 # General Server Config
 NODE_ENV=development
 PORT=1337
 
-# Lyft Config
-LYFT_CLIENT_ID=xxxxxx
-LYFT_CLIENT_SECRET=xxxxxx-xxxxxx
-LYFT_REFRESH_TOKEN=xxxxxx-xxxxxx
+# Token Management Config
+SKIP_AUTHORIZATION=
+AUTH_TOKEN=
 
 # Logging Config
 LOG_FILE=/tmp/micro.log
 SENTRY_DSN=https:<>@sentry.io/1
 ```
-
-## Development

--- a/lib/logging/sentry-transport.js
+++ b/lib/logging/sentry-transport.js
@@ -36,11 +36,21 @@ module.exports = class SentryTransport extends TransportStream {
       error.stack = metadata['stack'];
     }
     delete metadata['stack'];
+    delete metadata['request'];
 
     this.Sentry.configureScope(scope => {
       Object.keys(extra).forEach((key) => {
         scope.setExtra(key, extra[key]);
       });
+      if (metadata.hasOwnProperty('response')) {
+        const response = metadata['response'];
+        delete response['request'];
+        delete response['config'];
+        Object.keys(response).forEach((key) => {
+          scope.setExtra(key, response[key]);
+        });
+        delete metadata['response'];
+      }
       Object.keys(metadata).forEach((key) => {
         scope.setExtra(key, metadata[key]);
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1691,6 +1691,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -1699,6 +1700,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -1715,7 +1717,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1732,12 +1735,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -1750,12 +1755,14 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -1801,7 +1808,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -1827,7 +1835,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -1998,6 +2007,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2011,7 +2021,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2084,12 +2095,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -2163,7 +2176,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2221,7 +2235,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2259,6 +2274,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2310,7 +2326,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2368,6 +2385,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2378,6 +2396,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -2406,6 +2425,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -2461,7 +2481,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -3565,6 +3586,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4747,7 +4769,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtrip-micro",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtrip-micro",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,34 @@
 {
   "name": "roundtrip-micro",
   "version": "1.1.2",
-  "description": "",
+  "description": "RoundTrip MicroService Framework",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RideRoundTrip/roundtrip-micro.git"
+  },
+  "bugs": {
+    "url": "https://github.com/RideRoundTrip/roundtrip-micro/issues"
+  },
+  "homepage": "https://github.com/RideRoundTrip/roundtrip-micro#readme",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
     "test": "nyc ava",
     "coverage": "nyc report --reporter=html"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "directories": {
+    "lib": "lib"
+  },
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "dependencies": {
     "@sentry/node": "^4.5.3",
     "dotenv": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "roundtrip-micro",
+  "name": "@rideroundtrip/roundtrip-micro",
   "version": "1.1.2",
   "description": "RoundTrip MicroService Framework",
   "keywords": [],


### PR DESCRIPTION
@shalotelli 

This change is to handle `axios` error response to get more details in sentry.
Right now, we are only receiving sentries with 400 status code, this would give us the failure reason if available in error response object.

Also, can we publish a package for this repo on `npm`, so that our microservices can use the latest patch without any code change ?